### PR TITLE
fix: update footer version display to use environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+VERSION=1.0.0
 MONGO_URI=your_mongo_uri_here
 DEBUG=true
 JWT_SECRET=your_jwt_secret_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Note that the displayed date is in the format `dd-mm-yyyy`
 
+## [v1.1.0]
+
+> **Released:** `not yet`
+
+### Bug fixes
+- Change hard-coded version number in the footer to use variable from environment
+
 ## [v1.0.0]
 
 > **Released:** `05-07-2025`

--- a/src/client/components/Footer.jsx
+++ b/src/client/components/Footer.jsx
@@ -10,7 +10,7 @@ export default function Footer() {
             <div className="footer-left">
                 <p>&copy; {new Date().getFullYear()} Puneet Gopinath</p>
                 <p>Time-locked thoughts from your present self</p>
-                <p>v1.0.0-alpha — built with curiosity by Puneet Gopinath</p>
+                <p>${process.env?.VERSION || "v1.0.0"} — built with curiosity by Puneet Gopinath</p>
             </div>
 
             <div className="footer-right">

--- a/src/client/components/Footer.jsx
+++ b/src/client/components/Footer.jsx
@@ -10,7 +10,7 @@ export default function Footer() {
             <div className="footer-left">
                 <p>&copy; {new Date().getFullYear()} Puneet Gopinath</p>
                 <p>Time-locked thoughts from your present self</p>
-                <p>${process.env?.VERSION || "v1.0.0"} — built with curiosity by Puneet Gopinath</p>
+                <p>v{process.env?.VERSION || "1.0.0"} — built with curiosity by Puneet Gopinath</p>
             </div>
 
             <div className="footer-right">


### PR DESCRIPTION
## Checks
<!-- Please "check" the below options by replacing [ ] with [x] -->

I have...

- [x] Updated any necessary files such as the README.md and/or CHANGELOG.md.

## Description

Update Footer.jsx to use version from environment variable if available, if not fallback to hard-coded "v1.0.0"