### PR TITLE
fix: bug caused due to removing timezone offset in date change handler, the date is already present in local time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note that the displayed date is in the format `dd-mm-yyyy`
 
 - Configure express to trust specific proxy headers from process.env.TRUSTED_PROXIES [#14]
 - UX enhancement: Disable submit buttons during form submission [#18]
+- Fix a timezone offset issue on setting unlock date [#32]
 
 ### Refactorings
 
@@ -96,6 +97,7 @@ No changes to code were made after the beta release — this version simply mark
 - Bump nodemailer from 7.0.3 to 7.0.4 [#6](https://github.com/PuneetGopinath/chrono-capsule/pull/6)
 
 
+[#32]: https://github.com/PuneetGopinath/chrono-capsule/pull/32
 [#18]: https://github.com/PuneetGopinath/chrono-capsule/pull/18
 [#16]: https://github.com/PuneetGopinath/chrono-capsule/pull/16
 [#14]: https://github.com/PuneetGopinath/chrono-capsule/pull/14

--- a/src/client/components/dashboard/CapsuleForm.jsx
+++ b/src/client/components/dashboard/CapsuleForm.jsx
@@ -121,7 +121,6 @@ export default function CapsuleForm() {
 
     const handleDateChange = (e) => {
         const d = new Date(e.target.value);
-        d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
         setDate(d);
         setSelectedLabel(null);
     };


### PR DESCRIPTION
## Checks
<!-- Please "check" the below options by replacing [ ] with [x] -->

I have...

- [ ] Updated any necessary files such as the README.md and/or CHANGELOG.md.

## Description

Fix a small bug caused due to removing the timezone offset in date change handler